### PR TITLE
Use "127.0.0.1" for development or test

### DIFF
--- a/lib/mobilize-base/jobtracker.rb
+++ b/lib/mobilize-base/jobtracker.rb
@@ -82,17 +82,24 @@ module Mobilize
                   server_strings = server_line.split(",")[1..-1].reject{|t| t.strip.starts_with?(":")}
                   server_strings.map{|ss| ss.gsub("'","").gsub('"','').strip}
                 rescue
+                  # for dev/test
                   ["127.0.0.1"]
                 end
       servers
     end
 
     def Jobtracker.current_server
-      begin
-        Socket.gethostbyname(Socket.gethostname).first
-      rescue
-        nil
+      server = case Base.env
+        when %w[production staging]
+          begin
+            Socket.gethostbyname(Socket.gethostname).first
+          rescue
+            nil
+          end
+        else
+          "127.0.0.1"
       end
+      server
     end
 
     def Jobtracker.perform(id,*args)

--- a/lib/mobilize-base/jobtracker.rb
+++ b/lib/mobilize-base/jobtracker.rb
@@ -90,7 +90,7 @@ module Mobilize
 
     def Jobtracker.current_server
       server = case Base.env
-        when %w[production staging]
+        when "production", "staging"
           begin
             Socket.gethostbyname(Socket.gethostname).first
           rescue


### PR DESCRIPTION
Current version doesn't work in development or test because of multiple server environment.

This patch is just using "127.0.0.1" unless the env is production or staging.
