### PR TITLE
Changed the way to get spread sheet objects from the URL. 

### DIFF
--- a/lib/mobilize-base/handlers/google/gbook.rb
+++ b/lib/mobilize-base/handlers/google/gbook.rb
@@ -5,8 +5,7 @@ module Mobilize
     end
 
     def Gbook.find_by_http_url(http_url,gdrive_slot)
-      key = http_url.split("key=").last.split("#").first
-      Gdrive.root(gdrive_slot).spreadsheet_by_key(key)
+      Gdrive.root(gdrive_slot).spreadsheet_by_url(http_url)
     end
 
     def Gbook.find_by_path(path,gdrive_slot)


### PR DESCRIPTION
@denniss @jimreinhold 
Please review this. Changed the way to get spread object from the url due to the change of the URL structure in the new version. We will just use the existing external library method to do that instead of parsing urls in the mobilize own manner.
